### PR TITLE
Adds adds run method

### DIFF
--- a/spec/job_spec.cr
+++ b/spec/job_spec.cr
@@ -1,5 +1,18 @@
 require "./spec_helper"
 
+class TestJob
+  include JoobQ::Job
+  getter x
+  @queue = "example"
+
+  def initialize(@x : Int32 = 0)
+  end
+
+  def perform
+    @x += 1
+  end
+end
+
 module JoobQ
   describe Job do
     it "performs jobs at later time" do
@@ -7,6 +20,12 @@ module JoobQ
       job_id.should be_a UUID
 
       REDIS.zcard(Sets::Delayed.to_s).should eq 1
+    end
+
+    it "performs jobs every one second" do
+      job = TestJob.run(every: 1.second, x: 1)
+      sleep 3.seconds
+      job.x.should eq 3
     end
   end
 end

--- a/src/joobq/job.cr
+++ b/src/joobq/job.cr
@@ -25,6 +25,15 @@ module JoobQ
         JoobQ.scheduler.delay(job, within)
         job.jid
       end
+
+      # Allows for scheduling Jobs at an interval time span. 
+      #
+      # ```crystal
+      # TestJob.run(every: 1.second, x: 1)
+      # ```
+      def self.run(every : Time::Span, **args)
+        JoobQ.scheduler.every every, self, **args
+      end
     end
 
     abstract def perform

--- a/src/joobq/scheduler.cr
+++ b/src/joobq/scheduler.cr
@@ -34,6 +34,8 @@ module JoobQ
           spawn { job_instance.perform }
         end
       end
+
+      job_instance
     end
 
     def cron(pattern, &block : ->)


### PR DESCRIPTION
Allows for scheduling Jobs at an interval time span.

Eg.

```crystal
TestJob.run(every: 1.second, x: 1)
```